### PR TITLE
fix business unit name problem done

### DIFF
--- a/app/Http/Controllers/Admin/AdminBusinessUnitController.php
+++ b/app/Http/Controllers/Admin/AdminBusinessUnitController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\AdminBusinessUnitRequest;
 use App\Models\BusinessUnit;
+use App\Utils\NameNormalizer;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
@@ -14,7 +15,7 @@ class AdminBusinessUnitController extends Controller
 {
     public function index(): InertiaResponse
     {
-        $businessUnits = BusinessUnit::select('id', 'name')->get();
+        $businessUnits = BusinessUnit::select('id', 'display_name')->get();
 
         $viewData['businessUnits'] = $businessUnits;
 
@@ -23,7 +24,7 @@ class AdminBusinessUnitController extends Controller
 
     public function show(int $businessUnitId): InertiaResponse|RedirectResponse
     {
-        $businessUnit = BusinessUnit::where('id', $businessUnitId)->select('id', 'name')->first();
+        $businessUnit = BusinessUnit::where('id', $businessUnitId)->select('id', 'display_name')->first();
 
         if (! $businessUnit) {
             return redirect()->route('dashboard.business-unit.index')->with('error', 'Unidad de negocio con ID: '.$businessUnitId.' no encontrada.');
@@ -46,9 +47,9 @@ class AdminBusinessUnitController extends Controller
     {
         $validatedData = $request->validated();
         try {
-            if ($request->get('needs_error') == 'true') {
-                throw new Exception('Error de prueba en la creación de unidad de negocio.');
-            }
+            $displayName = $validatedData['display_name'];
+            $normalizedName = NameNormalizer::normalize($displayName);
+            $validatedData['name'] = $normalizedName;
 
             BusinessUnit::create($validatedData);
             $successMessage = 'La unidad de negocio: '.$validatedData['name'].', ha sido creada exitosamente.';
@@ -61,7 +62,7 @@ class AdminBusinessUnitController extends Controller
 
     public function edit(int $businessUnitId): InertiaResponse|RedirectResponse
     {
-        $businessUnit = BusinessUnit::where('id', $businessUnitId)->select('id', 'name')->first();
+        $businessUnit = BusinessUnit::where('id', $businessUnitId)->select('id', 'display_name')->first();
 
         if (! $businessUnit) {
             return redirect()->route('dashboard.business-unit.index')->with('error', 'Unidad de negocio con ID: '.$businessUnitId.' no encontrada.');
@@ -83,9 +84,9 @@ class AdminBusinessUnitController extends Controller
         $validatedData = $request->validated();
 
         try {
-            if ($request->get('needs_error') == 'true') {
-                throw new Exception('Error de prueba en la creación de unidad de negocio.');
-            }
+            $businessUnitName = $validatedData['display_name'];
+            $normalizedName = NameNormalizer::normalize($businessUnitName);
+            $validatedData['name'] = $normalizedName;
             $businessUnit->update($validatedData);
             $successMessage = 'La unidad de negocio: '.$validatedData['name'].', ha sido actualizada exitosamente.';
 

--- a/app/Http/Controllers/Quotation/QuotationController.php
+++ b/app/Http/Controllers/Quotation/QuotationController.php
@@ -14,7 +14,7 @@ class QuotationController extends Controller
 {
     public function selectBusinessUnit(): InertiaResponse
     {
-        $businessUnitNames = BusinessUnit::pluck('name');
+        $businessUnitNames = BusinessUnit::select('name', 'display_name')->get();
 
         $viewData['businessUnits'] = $businessUnitNames;
 
@@ -23,7 +23,7 @@ class QuotationController extends Controller
 
     public function getQuoteForBusinessUnit(string $businessUnitName): InertiaResponse|RedirectResponse
     {
-        $selectedBusinessUnit = BusinessUnit::whereRaw('LOWER(name) = ?', [strtolower($businessUnitName)])->first();
+        $selectedBusinessUnit = BusinessUnit::where('name', $businessUnitName)->first();
 
         if (! $selectedBusinessUnit) {
             return redirect()->route('quotation.select.business_unit')->with('error', 'No hay ninguna unidad de negocio con ese nombre');

--- a/app/Http/Requests/Admin/AdminBusinessUnitRequest.php
+++ b/app/Http/Requests/Admin/AdminBusinessUnitRequest.php
@@ -22,7 +22,7 @@ class AdminBusinessUnitRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'display_name' => ['required', 'string', 'max:255'],
         ];
     }
 
@@ -32,9 +32,9 @@ class AdminBusinessUnitRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'name.required' => 'El nombre es obligatorio.',
-            'name.string' => 'El nombre debe ser un texto.',
-            'name.max' => 'El nombre no puede superar los 255 caracteres.',
+            'display_name.required' => 'El nombre es obligatorio.',
+            'display_name.string' => 'El nombre debe ser un texto.',
+            'display_name.max' => 'El nombre no puede superar los 255 caracteres.',
         ];
     }
 }

--- a/app/Models/BusinessUnit.php
+++ b/app/Models/BusinessUnit.php
@@ -16,7 +16,7 @@ class BusinessUnit extends Model
      * $this->attributes['updated_at'] - Carbon - Record last update timestamp
      * $this->attributes['services'] - Service[] - Services associated with the business unit
      */
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'display_name'];
 
     // Getters
 
@@ -30,11 +30,21 @@ class BusinessUnit extends Model
         return $this->attributes['name'];
     }
 
+    public function getDisplayName(): string
+    {
+        return $this->attributes['display_name'];
+    }
+
     // Setters
 
     public function setName(string $name): void
     {
         $this->attributes['name'] = $name;
+    }
+
+    public function setDisplayName(string $displayName): void
+    {
+        $this->attributes['display_name'] = $displayName;
     }
 
     // Relationships

--- a/app/Utils/NameNormalizer.php
+++ b/app/Utils/NameNormalizer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Utils;
+
+class NameNormalizer
+{
+    /**
+     * Normalize a given name by trimming whitespace and converting to lowercase.
+     *
+     * @param string $name
+     * @return string
+     */
+    public static function normalize(string $value): string
+    {
+        $value = iconv('UTF-8', 'ASCII//TRANSLIT', $value);
+        $value = mb_strtolower($value, 'UTF-8');
+        $value = preg_replace('/[^a-z0-9]+/', '_', $value);
+        return trim($value, '_');
+    }
+}

--- a/database/migrations/0001_01_01_000005_create_business_units_table.php
+++ b/database/migrations/0001_01_01_000005_create_business_units_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('business_units', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('display_name');
             $table->foreignId('initial_condition_id')
                 ->nullable()
                 ->constrained('conditions')

--- a/resources/js/pages/admin/business-units/create.tsx
+++ b/resources/js/pages/admin/business-units/create.tsx
@@ -7,7 +7,7 @@ import { route } from 'ziggy-js';
 
 export default function Create() {
     const { data, setData, post, processing, errors } = useForm({
-        name: '',
+        display_name: '',
     });
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -30,20 +30,20 @@ export default function Create() {
                     <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
                         <form onSubmit={handleSubmit} className="space-y-8 p-8">
                             <div>
-                                <label htmlFor="name" className="mb-2 block text-sm font-medium text-gray-700">
+                                <label htmlFor="display_name" className="mb-2 block text-sm font-medium text-gray-700">
                                     Nombre <span className="text-red-500">*</span>
                                 </label>
 
                                 <input
-                                    id="name"
+                                    id="display_name"
                                     type="text"
-                                    value={data.name}
-                                    onChange={(e) => setData('name', e.target.value)}
+                                    value={data.display_name}
+                                    onChange={(e) => setData('display_name', e.target.value)}
                                     className="block w-full rounded-lg border border-gray-300 px-4 py-3 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
                                     placeholder="Ingrese el nombre de la unidad de negocio"
                                 />
 
-                                {errors.name && <p className="mt-2 text-sm text-red-600">{errors.name}</p>}
+                                {errors.display_name && <p className="mt-2 text-sm text-red-600">{errors.display_name}</p>}
                             </div>
 
                             {/* Botones */}

--- a/resources/js/pages/admin/business-units/edit.tsx
+++ b/resources/js/pages/admin/business-units/edit.tsx
@@ -7,7 +7,7 @@ import { route } from 'ziggy-js';
 
 interface BusinessUnit {
     id: number;
-    name: string;
+    display_name: string;
 }
 
 interface EditPageProps extends Record<string, unknown> {
@@ -22,7 +22,7 @@ export default function Edit() {
     const { businessUnit } = viewData;
 
     const { data, setData, put, processing, errors } = useForm({
-        name: businessUnit.name ?? '',
+        display_name: businessUnit.display_name ?? '',
     });
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -49,11 +49,11 @@ export default function Edit() {
                                 </label>
                                 <input
                                     type="text"
-                                    value={data.name}
-                                    onChange={(e) => setData('name', e.target.value)}
+                                    value={data.display_name}
+                                    onChange={(e) => setData('display_name', e.target.value)}
                                     className="block w-full rounded-lg border px-4 py-3 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
                                 />
-                                {errors.name && <p className="mt-2 text-sm text-red-600">{errors.name}</p>}
+                                {errors.display_name && <p className="mt-2 text-sm text-red-600">{errors.display_name}</p>}
                             </div>
 
                             {/* Botones */}

--- a/resources/js/pages/admin/business-units/index.tsx
+++ b/resources/js/pages/admin/business-units/index.tsx
@@ -7,7 +7,7 @@ import { Pencil, Plus, Trash2 } from 'lucide-react';
 
 interface BusinessUnit {
     id: number;
-    name: string;
+    display_name: string;
 }
 
 interface IndexPageProps extends Record<string, unknown> {
@@ -71,7 +71,7 @@ export default function Index() {
                                 className="cursor-pointer hover:bg-gray-100"
                             >
                                 <td className="border-b px-4 py-2 text-center">{unit.id}</td>
-                                <td className="border-b px-4 py-2 text-center font-medium">{capitalize(unit.name)}</td>
+                                <td className="border-b px-4 py-2 text-center font-medium">{capitalize(unit.display_name)}</td>
 
                                 <td className="border-b px-4 py-2" onClick={(e) => e.stopPropagation()}>
                                     <div className="flex justify-center gap-5">

--- a/resources/js/pages/admin/business-units/show.tsx
+++ b/resources/js/pages/admin/business-units/show.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 
 interface BusinessUnit {
     id: number;
-    name: string;
+    display_name: string;
 }
 
 interface Service {
@@ -49,7 +49,7 @@ export default function Show() {
                 <div className="mb-6 rounded-xl border bg-white p-6 shadow-sm">
                     <div className="flex items-center justify-between">
                         <div>
-                            <h2 className="text-2xl font-semibold text-slate-800">{capitalize(businessUnit.name)}</h2>
+                            <h2 className="text-2xl font-semibold text-slate-800">{capitalize(businessUnit.display_name)}</h2>
                         </div>
 
                         <div className="rounded-full bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700">ID #{businessUnit.id}</div>
@@ -57,7 +57,7 @@ export default function Show() {
                 </div>
 
                 <p className="mb-5 mt-1 text-sm text-gray-600">
-                    Servicios asociados a la unidad <strong>{businessUnit.name}</strong>
+                    Servicios asociados a la unidad <strong>{businessUnit.display_name}</strong>
                 </p>
 
                 <div className="rounded-lg border bg-white shadow">

--- a/resources/js/pages/business-units/select.tsx
+++ b/resources/js/pages/business-units/select.tsx
@@ -5,11 +5,16 @@ import GoHome from '@/components/ui/gohome';
 import Header from '@/components/ui/header';
 import { PageProps } from '@inertiajs/core';
 import { Link, usePage } from '@inertiajs/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+interface BusinessUnit {
+    name: string;
+    display_name: string;
+}
 
 type SelectPageProps = PageProps & {
     viewData: {
-        businessUnits: string[];
+        businessUnits: BusinessUnit[];
     };
     flash?: {
         error?: string;
@@ -19,7 +24,13 @@ type SelectPageProps = PageProps & {
 export default function SelectBusinessUnits() {
     const { viewData, flash } = usePage<SelectPageProps>().props;
     const error = flash?.error ?? '';
-    const [showError, setShowError] = useState(Boolean(error));
+    const [showError, setShowError] = useState(false);
+
+    useEffect(() => {
+        if (error) {
+            setShowError(true);
+        }
+    }, [error]);
     return (
         <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 via-white to-slate-50">
             <Header />
@@ -59,13 +70,13 @@ export default function SelectBusinessUnits() {
                     ) : (
                         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
                             {viewData.businessUnits.map((unit, i) => (
-                                <Link key={i} href={route('quotation.quote.business_unit', unit)}>
+                                <Link key={i} href={route('quotation.quote.business_unit', unit.name)}>
                                     <Card className="group relative h-44 rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:-translate-y-1 hover:shadow-xl">
                                         <div className="absolute inset-0 rounded-2xl border border-transparent transition-all group-hover:border-[#0693e3]" />
 
                                         <CardContent className="flex h-full flex-col items-center justify-center px-4 text-center">
                                             <CardTitle className="text-2xl font-semibold tracking-wide text-slate-800 transition-colors group-hover:text-[#0693e3]">
-                                                {unit.charAt(0).toUpperCase() + unit.slice(1).toLowerCase()}
+                                                {unit.display_name}
                                             </CardTitle>
                                         </CardContent>
                                     </Card>


### PR DESCRIPTION
This pull request introduces a new `display_name` field for business units, separating the user-facing name from the normalized internal `name`. It updates both backend and frontend to use `display_name` for user interactions, while ensuring the internal `name` is consistently normalized using a new utility. The migration, validation, controllers, and all relevant UI components have been updated accordingly.

**Backend changes:**

* Added a `display_name` column to the `business_units` table and updated the `BusinessUnit` model to include both `name` and `display_name`, with new getter and setter methods. (`database/migrations/0001_01_01_000005_create_business_units_table.php`, `app/Models/BusinessUnit.php`) [[1]](diffhunk://#diff-c789fc779cd888f705ebbe6b8102d98a6bb749c16283656fb08840f81057b121R17) [[2]](diffhunk://#diff-f3fe7ce3b5d0977565552f68f3ca3eb091c57764ccd06657636b9bb8b7e779c5L19-R19) [[3]](diffhunk://#diff-f3fe7ce3b5d0977565552f68f3ca3eb091c57764ccd06657636b9bb8b7e779c5R33-R49)
* Updated `AdminBusinessUnitController` to use `display_name` for all user-facing operations, and to generate the normalized internal `name` using the new `NameNormalizer` utility when creating or updating a business unit. (`app/Http/Controllers/Admin/AdminBusinessUnitController.php`, `app/Utils/NameNormalizer.php`) [[1]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910R8) [[2]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910L17-R18) [[3]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910L26-R27) [[4]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910L49-R52) [[5]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910L64-R65) [[6]](diffhunk://#diff-f5ec7a3c0217b1ff5d2f8a9f196b5fecf8e09562e1a70e3ec0b0e50457e75910L86-R89) [[7]](diffhunk://#diff-ea1a3ff68ef580202c808877520af77cbc5a9e97b0b1b5064ba70fa4f6c6eec2R1-R20)
* Changed validation rules and error messages in `AdminBusinessUnitRequest` to require and validate `display_name` instead of `name`. (`app/Http/Requests/Admin/AdminBusinessUnitRequest.php`) [[1]](diffhunk://#diff-e87547a11b59aaab6cd39340f3218a15f67f7f3e13d746ffb69386b3f765d43eL25-R25) [[2]](diffhunk://#diff-e87547a11b59aaab6cd39340f3218a15f67f7f3e13d746ffb69386b3f765d43eL35-R37)
* Updated `QuotationController` to fetch both `name` and `display_name`, and simplified the business unit lookup by using the normalized `name`. (`app/Http/Controllers/Quotation/QuotationController.php`) [[1]](diffhunk://#diff-63bc2453682fa7b069776e75b0817dd371a29fd8b0df59ec6b1d8e139cfe81e5L17-R17) [[2]](diffhunk://#diff-63bc2453682fa7b069776e75b0817dd371a29fd8b0df59ec6b1d8e139cfe81e5L26-R26)

**Frontend changes:**

* Updated all admin business unit pages (`create`, `edit`, `index`, `show`) to use `display_name` for display and form fields, and to expect/submit `display_name` instead of `name`. (`resources/js/pages/admin/business-units/create.tsx`, `resources/js/pages/admin/business-units/edit.tsx`, `resources/js/pages/admin/business-units/index.tsx`, `resources/js/pages/admin/business-units/show.tsx`) [[1]](diffhunk://#diff-1942840b213d75439be6c0837b419aa1846a59a6a2a24ad9b4913953968a5ef2L10-R10) [[2]](diffhunk://#diff-1942840b213d75439be6c0837b419aa1846a59a6a2a24ad9b4913953968a5ef2L33-R46) [[3]](diffhunk://#diff-5ee95ce2cc94672fc9191ec85a79d1ec1746f42a5c02ba6901db7b3df4708b5cL10-R10) [[4]](diffhunk://#diff-5ee95ce2cc94672fc9191ec85a79d1ec1746f42a5c02ba6901db7b3df4708b5cL25-R25) [[5]](diffhunk://#diff-5ee95ce2cc94672fc9191ec85a79d1ec1746f42a5c02ba6901db7b3df4708b5cL52-R56) [[6]](diffhunk://#diff-a9ac4df28cdb4fbb13a424e4e2d8be73561e24bd489585cb966c435f6dcfd39fL10-R10) [[7]](diffhunk://#diff-a9ac4df28cdb4fbb13a424e4e2d8be73561e24bd489585cb966c435f6dcfd39fL74-R74) [[8]](diffhunk://#diff-95460dec30100bbdf7e9b022e5fccf25a41cd5baccb58ad2d97d0ccfa72950a3L9-R9) [[9]](diffhunk://#diff-95460dec30100bbdf7e9b022e5fccf25a41cd5baccb58ad2d97d0ccfa72950a3L52-R60)
* Updated the business unit selection page to handle the new `BusinessUnit` structure, display `display_name`, and pass the normalized `name` to the backend when selecting a business unit. (`resources/js/pages/business-units/select.tsx`) [[1]](diffhunk://#diff-310a9350ea6f44a80cb11519c5713cd553d92f9338c71560243a10ff81a877ffL8-R17) [[2]](diffhunk://#diff-310a9350ea6f44a80cb11519c5713cd553d92f9338c71560243a10ff81a877ffL22-R33) [[3]](diffhunk://#diff-310a9350ea6f44a80cb11519c5713cd553d92f9338c71560243a10ff81a877ffL62-R79)