### PR TITLE
now it;s possible to add conditions to recent business lines

### DIFF
--- a/app/Http/Controllers/Admin/AdminDecisionTreeController.php
+++ b/app/Http/Controllers/Admin/AdminDecisionTreeController.php
@@ -21,7 +21,7 @@ class AdminDecisionTreeController extends Controller
             $viewData['decisionTrees'][] = [
                 $businessUnit->getId() => [
                     'conditions' => DecisionTreeHelper::buildTree($businessUnit),
-                    'initial_condition_id' => $businessUnit->getInitialCondition()->getId(),
+                    'initial_condition_id' => $businessUnit->getInitialCondition()?->getId() ?? null,
                 ]
             ];
         }


### PR DESCRIPTION
This pull request makes a minor but important update to the `index` method of the `AdminDecisionTreeController`. The change ensures that if a business unit does not have an initial condition, the `initial_condition_id` will be set to `null` instead of causing an error.

- Improved null safety for `initial_condition_id` assignment by using the nullsafe operator and a fallback to `null` in `AdminDecisionTreeController.php` (`index` method).