### PR TITLE
build errors fixed

### DIFF
--- a/resources/js/pages/admin/decision-tree/index.tsx
+++ b/resources/js/pages/admin/decision-tree/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import FlashAlert from '@/components/ui/flashalert';
 import AdminLayout from '@/layouts/admin-layout';
+import type { PageProps } from '@/types';
 import { router, usePage } from '@inertiajs/react';
 import { Plus, Star, Trash2, Trees } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -25,8 +26,12 @@ interface ConditionData {
     options: OptionData[];
 }
 
+type DecisionTreePageProps = PageProps<{
+    viewData: Record<string, unknown>;
+}>;
+
 export default function DecisionTreePage() {
-    const page = usePage<{ flash: Record<string, unknown> }>();
+    const page = usePage<DecisionTreePageProps & { flash: Record<string, unknown> }>();
     const { props } = page;
     const { flash } = page.props;
 


### PR DESCRIPTION
This pull request makes a minor update to the `DecisionTreePage` component to improve type safety by introducing a new `DecisionTreePageProps` type and updating the usage of `usePage` accordingly.

- Type improvements:
  * Added a `DecisionTreePageProps` type based on `PageProps` and updated the `usePage` hook to use this new type for better type safety in `index.tsx`. [[1]](diffhunk://#diff-a5b8e37a3f87d39deac4e8c103d3ab4ecd7a12512506fa258e80ca2a151fbf50R4) [[2]](diffhunk://#diff-a5b8e37a3f87d39deac4e8c103d3ab4ecd7a12512506fa258e80ca2a151fbf50R29-R34)