### PR TITLE
Feat/decision tree improvements

### DIFF
--- a/app/Helpers/DecisionTreeHelper.php
+++ b/app/Helpers/DecisionTreeHelper.php
@@ -38,6 +38,7 @@ class DecisionTreeHelper
                 'interaction_type' => $currentCondition->getInteractionType(),
                 'type' => $currentCondition->getType(),
                 'observation' => $currentCondition->getObservation(),
+                'multiple' => $currentCondition->getMultiple(),
             ];
 
             if ($next = $currentCondition->getNextCondition()) {
@@ -51,6 +52,7 @@ class DecisionTreeHelper
                 foreach ($currentCondition->getOptions() as $option) {
                     $optionData = [
                         'label' => $option->getLabel(),
+                        'value' => $option->getValue(),
                         'is_other' => $option->isOther(),
                     ];
 
@@ -102,6 +104,7 @@ class DecisionTreeHelper
                         'interaction_type' => $c['interaction_type'] ?? 'input',
                         'type' => $c['type'] ?? 'text',
                         'observation' => $c['observation'] ?? null,
+                        'multiple' => $c['multiple'] ?? false,
                         'business_unit_id' => $businessUnit->getId(),
                     ]);
 
@@ -125,6 +128,7 @@ class DecisionTreeHelper
                         foreach ($c['options'] as $opt) {
                             ConditionOption::create([
                                 'label' => $opt['label'] ?? '',
+                                'value' => $opt['value'] ?? null, // 🔥 AQUÍ LO PONES
                                 'condition_id' => $newId,
                                 'next_condition_id' => (! empty($opt['next_condition']) ? ($idMap[$opt['next_condition']] ?? null) : null),
                                 'is_other' => ! empty($opt['is_other']),

--- a/app/Models/Condition.php
+++ b/app/Models/Condition.php
@@ -34,6 +34,7 @@ class Condition extends Model
         'observation',
         'next_condition_id',
         'business_unit_id',
+        'multiple',
     ];
 
     public $timestamps = false;
@@ -129,6 +130,18 @@ class Condition extends Model
     public function setObservation(?string $value): void
     {
         $this->attributes['observation'] = $value;
+    }
+
+    // Multiple
+
+    public function getMultiple(): bool
+    {
+    return (bool) ($this->attributes['multiple'] ?? false);
+    }
+
+    public function setMultiple(bool $value): void
+    {
+        $this->attributes['multiple'] = $value;
     }
 
 }

--- a/app/Models/ConditionOption.php
+++ b/app/Models/ConditionOption.php
@@ -25,6 +25,7 @@ class ConditionOption extends Model
      */
     protected $fillable = [
         'label',
+        'value',
         'condition_id',
         'next_condition_id',
         'is_other',
@@ -120,5 +121,12 @@ class ConditionOption extends Model
     public function setIsOther(bool $value): void
     {
         $this->attributes['is_other'] = $value;
+    }
+
+    // Value
+
+        public function getValue(): ?string
+    {
+        return $this->attributes['value'] ?? null;
     }
 }

--- a/database/migrations/2026_04_03_183755_add_multiple_to_conditions_table.php
+++ b/database/migrations/2026_04_03_183755_add_multiple_to_conditions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+        public function up(): void
+    {
+        Schema::table('conditions', function (Blueprint $table) {
+            $table->boolean('multiple')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conditions', function (Blueprint $table) {
+            $table->dropColumn('multiple');
+        });
+    }
+};

--- a/database/migrations/2026_04_03_215850_add_value_to_condition_options_table.php
+++ b/database/migrations/2026_04_03_215850_add_value_to_condition_options_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('condition_options', function (Blueprint $table) {
+            $table->string('value')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('condition_options', function (Blueprint $table) {
+            $table->dropColumn('value');
+        });
+    }
+};

--- a/resources/js/components/ui/breadcrumbs.tsx
+++ b/resources/js/components/ui/breadcrumbs.tsx
@@ -1,55 +1,44 @@
 import { Link, usePage } from '@inertiajs/react';
 
 const routeNameMap: Record<string, string> = {
-    dashboard: 'Panel',
-    cotizar: 'Cotizar',
-    'portafolio-de-servicios': 'Portafolio de servicios',
-    servicios: 'Servicios',
-    perfil: 'Perfil',
-    auditoria: 'Auditoría',
-    consultoria: 'Consultoría',
-    formacion: 'Formación',
+  dashboard: 'Panel',
+  'portafolio-de-servicios': 'Portafolio de servicios',
+  servicios: 'Servicios',
+  perfil: 'Perfil',
 };
 
-function displaySegment(segment: string): string {
-    const mapped = routeNameMap[segment.toLowerCase()];
-    if (mapped) return mapped;
-    return segment.replace(/-/g, ' ');
-}
-
 export default function Breadcrumbs() {
-    const { url } = usePage();
-    const segments = url.split('/').filter(Boolean);
+  const { url } = usePage();
+  const segments = url.split('/').filter(Boolean);
 
-    return (
-        <nav
-            aria-label="Ruta"
-            className="flex flex-wrap items-center justify-center gap-x-0.5 gap-y-1 text-center text-sm font-medium text-white/90 sm:text-base"
-        >
-            <Link href={route('home')} className="rounded px-0.5 transition-colors hover:text-[#7dd3fc]">
-                Inicio
-            </Link>
-            {segments.map((segment, index) => {
-                const href = '/' + segments.slice(0, index + 1).join('/');
-                const isLast = index === segments.length - 1;
-                const label = displaySegment(segment);
-                return (
-                    <span key={`${segment}-${index}`} className="flex items-center gap-0.5 sm:gap-1">
-                        <span className="px-1 text-white/35 sm:px-1.5" aria-hidden>
-                            /
-                        </span>
-                        {isLast ? (
-                            <span className="max-w-[11rem] truncate font-semibold capitalize text-white sm:max-w-[min(24rem,50vw)]">
-                                {label}
-                            </span>
-                        ) : (
-                            <Link href={href} className="rounded px-0.5 capitalize transition-colors hover:text-[#7dd3fc]">
-                                {label}
-                            </Link>
-                        )}
-                    </span>
-                );
-            })}
-        </nav>
-    );
+  return (
+    <nav className="flex items-center justify-center gap-2 text-lg text-white">
+      <Link
+        href={route('home')}
+        className="font-semibold text-white"
+      >
+        Inicio
+      </Link>
+      {segments.map((segment, index) => {
+        const href = '/' + segments.slice(0, index + 1).join('/');
+        const isLast = index === segments.length - 1;
+        const displayName = routeNameMap[segment] || segment.replace('-', ' ');
+        return (
+          <span key={index} className="flex items-center gap-2">
+            <span className="mx-2 text-white">→</span>
+            {isLast ? (
+              <span className="relative font-semibold text-cyan-400 uppercase">
+                {displayName}
+              <span className="absolute -bottom-1 left-0 right-0 h-[2px] bg-cyan-400 rounded-full" />
+            </span>
+            ) : (
+              <Link href={href} className="font-semibold text-white">
+                {displayName}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
 }

--- a/resources/js/components/ui/header.tsx
+++ b/resources/js/components/ui/header.tsx
@@ -3,26 +3,39 @@ import { Link } from '@inertiajs/react';
 import Breadcrumbs from './breadcrumbs';
 
 export default function Header() {
-    return (
-        <header className="animate-slide-up fixed left-0 right-0 top-0 z-50 min-h-[88px] border-b border-slate-700/50 bg-[#1a1e2b] shadow-md backdrop-blur-xl">
-            <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-[#0693e3]/60 to-transparent" aria-hidden />
-            <div className="relative mx-auto flex min-h-[88px] max-w-7xl items-center justify-between gap-3 px-4 py-4 sm:px-6 sm:py-5">
-                <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-14 sm:px-28">
-                    <div className="pointer-events-auto max-w-[min(100%,30rem)] sm:max-w-none">
-                        <Breadcrumbs />
-                    </div>
-                </div>
-                <div className="relative z-10 ml-auto shrink-0">
-                    <Link
-                        href={route('dashboard')}
-                        className="group inline-flex items-center gap-2 rounded-xl border-2 border-slate-500/80 bg-white/95 px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-all duration-300 hover:border-[#0693e3] hover:bg-[#0693e3] hover:text-white hover:shadow-lg hover:shadow-[#0693e3]/25"
-                    >
-                        <span className="hidden sm:inline">Admin</span>
-                        <span className="sm:hidden">Panel</span>
-                        <Shield className="h-4 w-4 shrink-0 transition-transform duration-300 group-hover:scale-110" aria-hidden />
-                    </Link>
-                </div>
-            </div>
-        </header>
-    );
+  return (
+    <header className="animate-slide-up fixed left-0 right-0 top-0 z-50 border-b border-slate-200/80 bg-[#1a1e2b] backdrop-blur-xl">
+      {/* Línea decorativa gradiente inferior */}
+      <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-gradient-to-r from-transparent via-[#0693e3]/50 to-transparent opacity-50" />
+
+      {/* Vista Mobile */}
+      <div className="flex flex-col items-center gap-2 px-4 py-2 md:hidden">
+          <Link
+              href={route('dashboard')}
+              className="group inline-flex items-center gap-2 rounded-xl border-2 border-slate-500/80 bg-white/95 px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-all duration-300 hover:border-[#0693e3] hover:bg-[#0693e3] hover:text-white hover:shadow-lg hover:shadow-[#0693e3]/25"
+          >
+              Admin
+              <Shield className="h-4 w-4 shrink-0 transition-transform duration-300 group-hover:scale-110" aria-hidden />
+          </Link>
+          <Breadcrumbs />
+      </div>
+
+      {/* Vista PC */}
+      <div className="relative hidden md:flex items-center justify-between px-6 py-4 container mx-auto min-h-[60px]">
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
+              <Breadcrumbs />
+          </div>
+          <div className="ml-auto">
+              <Link
+                  href={route('dashboard')}
+                  className="group inline-flex items-center gap-2 rounded-xl border-2 border-slate-500/80 bg-white/95 px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-all duration-300 hover:border-[#0693e3] hover:bg-[#0693e3] hover:text-white hover:shadow-lg hover:shadow-[#0693e3]/25"
+              >
+                  <span className="hidden sm:inline">Admin</span>
+                  <span className="sm:hidden">Panel</span>
+                  <Shield className="h-4 w-4 shrink-0 transition-transform duration-300 group-hover:scale-110" aria-hidden />
+              </Link>
+          </div>
+      </div>
+    </header>
+  );
 }

--- a/resources/js/components/ui/tree/GestionLine.tsx
+++ b/resources/js/components/ui/tree/GestionLine.tsx
@@ -695,6 +695,11 @@ export default function GestionLine({ viewData }: GestionLineProps) {
                                         ? savedSnapshot.selectedServices.join(', ')
                                         : '-'}{' '}
                                 </p>
+
+                                <p className="text-sm text-slate-700">
+                                    <strong>Profesional:</strong>{' '}
+                                    {selectedProfessionalId !== null ? `Profesional #${selectedProfessionalId}` : 'Sin preferencia'}
+                                </p>
                                 <div className="mt-2 text-sm">
                                     <strong>Respuestas:</strong>
                                     <ul className="mt-1 list-inside list-disc text-slate-700">

--- a/resources/js/components/ui/tree/GestionLine.tsx
+++ b/resources/js/components/ui/tree/GestionLine.tsx
@@ -19,6 +19,7 @@ export interface ViewData {
             type: string;
             observation?: string | null;
             next_condition?: number;
+            multiple?: boolean;
         };
     };
     initial_condition_id?: number | null;
@@ -140,16 +141,49 @@ export default function GestionLine({ viewData }: GestionLineProps) {
                 let valueDisplay: string;
                 if (cond && cond.interaction_type === 'options') {
                     const opts = Array.isArray((cond as any).options) ? (cond as any).options : [];
-                    if (typeof v === 'object' && v !== null && 'optionIndex' in (v as Record<string, unknown>)) {
-                        const optionIndex = (v as { optionIndex: number }).optionIndex;
-                        const textValue = (v as { text?: string }).text;
-                        valueDisplay = textValue && textValue.trim() !== '' ? textValue : opts[optionIndex]?.label || String(optionIndex);
-                    } else if (typeof v === 'number' && opts[v]) {
-                        valueDisplay = opts[v].label || String(v);
-                    } else {
-                        valueDisplay = String(v);
+
+                    // Opción Múltiple
+                    if (cond.multiple) {
+                        if (Array.isArray(v)) {
+                            valueDisplay = [...v].sort((a: any, b: any) => {
+                            const aIsOther = typeof a === 'object' && a !== null && 'optionIndex' in a;
+                            const bIsOther = typeof b === 'object' && b !== null && 'optionIndex' in b;
+                            if (aIsOther && !bIsOther) return 1;
+                            if (!aIsOther && bIsOther) return -1;
+                            return 0;
+                        }).map((item: any) => {
+                                if (typeof item === 'number') {
+                                    return opts[item]?.label || String(item);
+                                }
+                                if (typeof item === 'object' && item !== null && 'optionIndex' in item) {
+                                    // es un "Otro" con texto libre
+                                    return item.text?.trim()
+                                        ? item.text
+                                        : opts[item.optionIndex]?.label || String(item.optionIndex);
+                                }
+                                return String(item);
+                            }).join(', ');
+                        } else {
+                            valueDisplay = '';
+                        }
                     }
-                } else if (cond && cond.interaction_type === 'range') {
+                    // Opción única
+                    else {
+                        if (typeof v === 'object' && v !== null && 'optionIndex' in (v as Record<string, unknown>)) {
+                            const optionIndex = (v as { optionIndex: number }).optionIndex;
+                            const textValue = (v as { text?: string }).text;
+                            valueDisplay =
+                                textValue && textValue.trim() !== ''
+                                    ? textValue
+                                    : opts[optionIndex]?.label || String(optionIndex);
+                        } else if (typeof v === 'number' && opts[v]) {
+                            valueDisplay = opts[v].label || String(v);
+                        } else {
+                            valueDisplay = String(v);
+                        }
+                    }
+                }
+                else if (cond && cond.interaction_type === 'range') {
                     const isRange =
                         typeof v === 'object' && v !== null && 'min' in (v as Record<string, unknown>) && 'max' in (v as Record<string, unknown>);
                     const min = isRange ? (v as { min: any; max: any }).min : '';
@@ -710,19 +744,50 @@ export default function GestionLine({ viewData }: GestionLineProps) {
                                                 let valueDisplay: string;
                                                 if (cond && cond.interaction_type === 'options') {
                                                     const opts = Array.isArray((cond as any).options) ? (cond as any).options : [];
-                                                    if (typeof v === 'object' && v !== null && 'optionIndex' in (v as Record<string, unknown>)) {
-                                                        const optionIndex = (v as { optionIndex: number }).optionIndex;
-                                                        const textValue = (v as { text?: string }).text;
-                                                        valueDisplay =
-                                                            textValue && textValue.trim() !== ''
-                                                                ? textValue
-                                                                : opts[optionIndex]?.label || String(optionIndex);
-                                                    } else if (typeof v === 'number' && opts[v]) {
-                                                        valueDisplay = opts[v].label || String(v);
+
+                                                // Opción Múltiple
+                                                if (cond.multiple) {
+                                                    if (Array.isArray(v)) {
+                                                        valueDisplay = [...v].sort((a: any, b: any) => {
+                                                        const aIsOther = typeof a === 'object' && a !== null && 'optionIndex' in a;
+                                                        const bIsOther = typeof b === 'object' && b !== null && 'optionIndex' in b;
+                                                        if (aIsOther && !bIsOther) return 1;
+                                                        if (!aIsOther && bIsOther) return -1;
+                                                        return 0;
+                                                    }).map((item: any) => {
+                                                            if (typeof item === 'number') {
+                                                                return opts[item]?.label || String(item);
+                                                            }
+                                                            if (typeof item === 'object' && item !== null && 'optionIndex' in item) {
+                                                                // es un "Otro" con texto libre
+                                                                return item.text?.trim()
+                                                                    ? item.text
+                                                                    : opts[item.optionIndex]?.label || String(item.optionIndex);
+                                                            }
+                                                            return String(item);
+                                                        }).join(', ');
                                                     } else {
-                                                        valueDisplay = String(v);
+                                                        valueDisplay = '';
                                                     }
-                                                } else if (cond && cond.interaction_type === 'range') {
+                                                }
+                                                
+                                                    // Opción única
+                                                    else {
+                                                        if (typeof v === 'object' && v !== null && 'optionIndex' in (v as Record<string, unknown>)) {
+                                                            const optionIndex = (v as { optionIndex: number }).optionIndex;
+                                                            const textValue = (v as { text?: string }).text;
+                                                            valueDisplay =
+                                                                textValue && textValue.trim() !== ''
+                                                                    ? textValue
+                                                                    : opts[optionIndex]?.label || String(optionIndex);
+                                                        } else if (typeof v === 'number' && opts[v]) {
+                                                            valueDisplay = opts[v].label || String(v);
+                                                        } else {
+                                                            valueDisplay = String(v);
+                                                        }
+                                                    }
+                                                }
+                                                else if (cond && cond.interaction_type === 'range') {
                                                     // expect v to be { min, max }
                                                     const min =
                                                         typeof v === 'object' && v !== null && 'min' in (v as Record<string, unknown>)
@@ -878,29 +943,74 @@ function ConditionStepper({
                         <div key={i} className="space-y-2">
                             <label className="flex cursor-pointer items-center gap-3 rounded-lg py-1 transition-colors hover:text-[#0693e3]">
                                 <input
-                                    type="radio"
+                                    type={cond.multiple ? "checkbox" : "radio"}
                                     name={`opt-${currentId}`}
-                                    checked={selectedIndex === i}
+                                    checked={
+                                        cond.multiple
+                                            ? Array.isArray(currentAnswer) &&
+                                            currentAnswer.some((item: any) =>
+                                                typeof item === 'number' ? item === i : item?.optionIndex === i
+                                            )
+                                            : selectedIndex === i
+                                    }
                                     onChange={() => {
-                                        if (conditionOptionIsOther(o)) {
-                                            onAnswer(String(currentId), { optionIndex: i, text: '' });
+                                        if (cond.multiple) {
+                                            const current = Array.isArray(currentAnswer) ? currentAnswer : [];
+                                            const exists = current.some((item: any) =>
+                                                typeof item === 'number' ? item === i : item?.optionIndex === i
+                                            );
+                                            const updated = exists
+                                                ? current.filter((item: any) =>
+                                                    typeof item === 'number' ? item !== i : item?.optionIndex !== i
+                                                )
+                                                : conditionOptionIsOther(o)
+                                                    ? [...current, { optionIndex: i, text: '' }]
+                                                    : [...current, i];
+                                            onAnswer(String(currentId), updated);
                                         } else {
-                                            onAnswer(String(currentId), i);
+                                            if (conditionOptionIsOther(o)) {
+                                                onAnswer(String(currentId), { optionIndex: i, text: '' });
+                                            } else {
+                                                onAnswer(String(currentId), i);
+                                            }
+                                            setSelectedOption(i);
                                         }
-                                        setSelectedOption(i);
                                     }}
                                     className="h-4 w-4 shrink-0 border-slate-300 text-[#0693e3] focus:ring-[#0693e3]"
                                 />
                                 <span className="text-sm font-medium text-slate-800">{o.label || '(sin etiqueta)'}</span>
                             </label>
 
-                            {conditionOptionIsOther(o) && selectedIndex === i && (
+                            {conditionOptionIsOther(o) && (
+                                cond.multiple
+                                    ? Array.isArray(currentAnswer) && currentAnswer.some((item: any) => item?.optionIndex === i)
+                                    : selectedIndex === i
+                            ) && (
                                 <input
                                     className={inputClass}
                                     type="text"
                                     placeholder="Escribe tu respuesta"
-                                    value={selectedText}
-                                    onChange={(e) => onAnswer(String(currentId), { optionIndex: i, text: e.target.value })}
+                                    value={
+                                        cond.multiple
+                                            ? (Array.isArray(currentAnswer)
+                                                ? currentAnswer.find((item: any) => item?.optionIndex === i)
+                                                : null
+                                            )?.text ?? ''
+                                            : selectedText ?? ''
+                                    }
+                                    onChange={(e) => {
+                                        if (cond.multiple) {
+                                            const current = Array.isArray(currentAnswer) ? currentAnswer : [];
+                                            const updated = current.map((item: any) =>
+                                                typeof item === 'object' && item !== null && item.optionIndex === i
+                                                    ? { ...item, text: e.target.value }
+                                                    : item
+                                            );
+                                            onAnswer(String(currentId), updated);
+                                        } else {
+                                            onAnswer(String(currentId), { optionIndex: i, text: e.target.value });
+                                        }
+                                    }}
                                 />
                             )}
                         </div>
@@ -965,26 +1075,35 @@ function ConditionStepper({
             }
         }
 
+        const currentAnswer = answers[String(currentId)];
         if (cond.interaction_type === 'options') {
-            const sel = answers[String(currentId)];
-            const opts = Array.isArray((cond as any).options) ? (cond as any).options : [];
-            if (sel === undefined || sel === null) {
-                setValidationError('Selecciona una opción');
+            if (cond.multiple) {
+                if (!Array.isArray(currentAnswer) || currentAnswer.length === 0) {
+                    setValidationError('Selecciona al menos una opción');
+                    return;
+                }
+                // Verificar que si hay "Otro" seleccionado, tenga texto
+                const otherItem = currentAnswer.find((item: any) =>
+                    typeof item === 'object' && item !== null && 'optionIndex' in item
+                );
+                if (otherItem && (!otherItem.text || otherItem.text.trim() === '')) {
+                    setValidationError('Escribe tu respuesta en el campo "Otro"');
+                    return;
+                }
             } else {
-                const selectedIndex =
-                    typeof sel === 'number'
-                        ? sel
-                        : typeof sel === 'object' && sel !== null && 'optionIndex' in sel
-                          ? (sel as { optionIndex: number }).optionIndex
-                          : null;
-                if (selectedIndex === null || selectedIndex < 0 || selectedIndex >= opts.length) {
+                if (currentAnswer === undefined) {
                     setValidationError('Selecciona una opción');
-                } else if (conditionOptionIsOther(opts[selectedIndex])) {
-                    const textValue =
-                        typeof sel === 'object' && sel !== null && 'text' in sel
-                            ? ((sel as { text?: string }).text ?? '')
-                            : '';
-                    if (String(textValue).trim() === '') setValidationError('Escribe tu respuesta');
+                    return;
+                }
+                // Verificar que si eligió "Otro", tenga texto
+                if (
+                    typeof currentAnswer === 'object' &&
+                    currentAnswer !== null &&
+                    'optionIndex' in currentAnswer &&
+                    (!currentAnswer.text || currentAnswer.text.trim() === '')
+                ) {
+                    setValidationError('Escribe tu respuesta en el campo "Otro"');
+                    return;
                 }
             }
         }

--- a/resources/js/pages/admin/decision-tree/index.tsx
+++ b/resources/js/pages/admin/decision-tree/index.tsx
@@ -27,6 +27,8 @@ interface ConditionData {
     observation: string;
     next_condition?: number;
     options: OptionData[];
+    multiple?: boolean;
+    has_other?: boolean;
 }
 
 type DecisionTreePageProps = PageProps<{
@@ -265,6 +267,8 @@ export default function DecisionTreePage() {
                               is_other: !!o.is_other,
                           }))
                         : [],
+                    multiple: c.multiple === true || c.multiple === 1,
+                    has_other: c.has_other === true || c.has_other === 1,
                 }));
             } else if (raw && typeof raw === 'object') {
                 // received as an object keyed by condition id -> convert to array
@@ -282,6 +286,8 @@ export default function DecisionTreePage() {
                               is_other: !!o.is_other,
                           }))
                         : [],
+                    multiple: c.multiple === true || c.multiple === 1,
+                    checked: c.options ? c.options.some((o: any) => o.is_other) : false,
                 }));
             } else {
                 trees[id] = [];
@@ -321,6 +327,8 @@ export default function DecisionTreePage() {
             type: 'text',
             observation: '',
             options: [],
+            multiple: false,
+            has_other: false,
         };
         setConditionsByBU((prev) => {
             const prevList = prev[buId] ?? [];
@@ -367,6 +375,13 @@ export default function DecisionTreePage() {
         const allowedTypes: ValueType[] = ['text', 'number', 'date'];
 
         Object.entries(payload).forEach(([buId, data]) => {
+
+            if (data.initial_condition_id === null || data.initial_condition_id === undefined) {
+                if (data.conditions.length > 0) {
+                    errors.push(`Unidad ${buId}: debes marcar una condición como inicial antes de guardar`);
+                }
+            }
+
             if (!Array.isArray(data.conditions)) {
                 errors.push(`Unidad ${buId}: 'conditions' debe ser un arreglo`);
                 return;
@@ -422,7 +437,13 @@ export default function DecisionTreePage() {
 
             const cyclePath = findCyclePathInGraph(graph);
             if (cyclePath !== null) {
-                errors.push(`Unidad ${buId}: ciclo detectado entre condiciones: ${cyclePath.join(' -> ')}`);
+                const buConditions = data.conditions;
+                const cycleLabels = cyclePath.map((id) => {
+                const found = buConditions.find((c) => c.id === id);
+                
+                return found?.label?.trim() || `Condición #${id}`;
+                });
+                errors.push(`Unidad ${buId}: ciclo detectado entre condiciones: ${cycleLabels.join(' -> ')}`);
             }
         });
 
@@ -957,6 +978,7 @@ export default function DecisionTreePage() {
                                                                 interaction_type: e.target.value as InteractionType,
                                                                 options: e.target.value === 'options' ? (c.options ?? []) : [],
                                                                 next_condition: undefined,
+                                                                multiple: c.multiple ?? false,
                                                             })
                                                         }
                                                     >
@@ -1008,20 +1030,14 @@ export default function DecisionTreePage() {
                                                     Siguiente condición
                                                 </label>
                                                 <p className="mb-2 text-xs text-slate-500">
-                                                    A dónde salta el flujo al terminar esta pregunta (si no usas opciones con destino propio).
+                                                    A dónde salta el flujo al terminar esta pregunta.
                                                 </p>
                                                 {conditionSelectForBU(
                                                     Number(selectedBU),
                                                     idx,
                                                     c.next_condition,
                                                     (v) => isEditing && updateConditionForBU(Number(selectedBU), idx, { next_condition: v }),
-                                                    !isEditing || anyOptionLeads,
-                                                )}
-                                                {anyOptionLeads && (
-                                                    <p className="mt-2 flex items-start gap-1.5 text-xs text-slate-600">
-                                                        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400" aria-hidden />
-                                                        Desactivado: al menos una opción ya define el siguiente paso.
-                                                    </p>
+                                                    !isEditing,
                                                 )}
                                             </div>
 
@@ -1045,74 +1061,105 @@ export default function DecisionTreePage() {
                                                         </Button>
                                                     </div>
 
-                                                    {(c.options ?? []).map((option, optIdx) => (
-                                                        <div
-                                                            key={optIdx}
-                                                            className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
-                                                        >
-                                                            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
-                                                                <div className="min-w-0 flex-1">
-                                                                    <label className="mb-1 block text-xs font-medium text-slate-600">Texto mostrado</label>
-                                                                    <input
-                                                                        disabled={!isEditing}
-                                                                        className={textInputClass}
-                                                                        placeholder="Ej.: Sí / No / Otra"
-                                                                        value={option.label}
-                                                                        onChange={(e) =>
-                                                                            isEditing &&
-                                                                            updateOptionForBU(Number(selectedBU), idx, optIdx, {
-                                                                                label: e.target.value,
-                                                                            })
-                                                                        }
-                                                                    />
-                                                                </div>
-                                                                <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-700 sm:pb-2">
-                                                                    <input
-                                                                        type="checkbox"
-                                                                        className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                                                                        checked={option.is_other}
-                                                                        disabled={!isEditing}
-                                                                        onChange={(e) =>
-                                                                            isEditing &&
-                                                                            updateOptionForBU(Number(selectedBU), idx, optIdx, {
-                                                                                is_other: e.target.checked,
-                                                                            })
-                                                                        }
-                                                                    />
-                                                                    Permitir &quot;Otro&quot;
-                                                                </label>
-                                                            </div>
-                                                            <div>
-                                                                <label className="mb-1 block text-xs font-medium text-slate-600">
-                                                                    Siguiente condición al elegir esta opción
-                                                                </label>
-                                                                {conditionSelectForBU(
-                                                                    Number(selectedBU),
-                                                                    idx,
-                                                                    option.next_condition,
-                                                                    (v) =>
-                                                                        isEditing &&
-                                                                        updateOptionForBU(Number(selectedBU), idx, optIdx, { next_condition: v }),
-                                                                    !isEditing || c.next_condition !== undefined,
-                                                                )}
-                                                            </div>
-                                                            <div className="flex justify-end border-t border-slate-100 pt-3">
-                                                                <Button
-                                                                    type="button"
-                                                                    variant="ghost"
-                                                                    size="sm"
-                                                                    className="text-red-600 hover:bg-red-50 hover:text-red-700"
-                                                                    disabled={!isEditing}
-                                                                    onClick={() =>
-                                                                        isEditing && removeOptionForBU(Number(selectedBU), idx, optIdx)
-                                                                    }
-                                                                >
-                                                                    <Trash2 className="h-4 w-4" aria-hidden />
-                                                                    Quitar opción
-                                                                </Button>
-                                                            </div>
+                                                    <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
+                                                        <div>
+                                                            <p className="text-sm font-medium text-slate-800">Tipo de selección</p>
+                                                            <p className="text-xs text-slate-500">¿El usuario puede elegir una o varias opciones?</p>
                                                         </div>
-                                                    ))}
+                                                        <div className="flex gap-2">
+                                                            <button
+                                                                type="button"
+                                                                disabled={!isEditing}
+                                                                onClick={() => isEditing && updateConditionForBU(Number(selectedBU), idx, { multiple: false })}
+                                                                className={`rounded-lg border px-3 py-1.5 text-xs font-semibold transition ${
+                                                                    !c.multiple
+                                                                        ? 'border-[#0693e3] bg-[#0693e3]/10 text-[#047ac0]'
+                                                                        : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
+                                                                } disabled:cursor-not-allowed disabled:opacity-50`}
+                                                            >
+                                                                Selección única
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                disabled={!isEditing}
+                                                                onClick={() => isEditing && updateConditionForBU(Number(selectedBU), idx, { multiple: true })}
+                                                                className={`rounded-lg border px-3 py-1.5 text-xs font-semibold transition ${
+                                                                    c.multiple
+                                                                        ? 'border-[#0693e3] bg-[#0693e3]/10 text-[#047ac0]'
+                                                                        : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
+                                                                } disabled:cursor-not-allowed disabled:opacity-50`}
+                                                            >
+                                                                Selección múltiple
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                    <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-700">
+                                                       <input
+                                                            type="checkbox"
+                                                            checked={c.options?.some(o => o.is_other)}
+                                                            onChange={(e) => {
+                                                                if (e.target.checked) {
+                                                                updateConditionForBU(Number(selectedBU), idx, {
+                                                                    options: [
+                                                                    ...(c.options ?? []),
+                                                                    { label: 'Otro', is_other: true }
+                                                                    ]
+                                                                });
+                                                                } else {
+                                                                updateConditionForBU(Number(selectedBU), idx, {
+                                                                    options: (c.options ?? []).filter(o => !o.is_other)
+                                                                });
+                                                                }
+                                                            }}
+                                                            />
+                                                        Permitir respuesta &quot;Otro&quot; (campo libre al final de las opciones)
+                                                    </label>
+                                                    
+                                                    {/* Opciones normales primero */}
+                                                    {(c.options ?? []).filter(option => !option.is_other).map((option, optIdx) => {
+                                                        const realIdx = (c.options ?? []).findIndex(o => o === option);
+                                                        return (
+                                                            <div key={realIdx} className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                                                                <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
+                                                                    <div className="min-w-0 flex-1">
+                                                                        <label className="mb-1 block text-xs font-medium text-slate-600">Texto mostrado</label>
+                                                                        <input
+                                                                            disabled={!isEditing}
+                                                                            className={textInputClass}
+                                                                            placeholder="Ej.: Sí / No / Otra"
+                                                                            value={option.label}
+                                                                            onChange={(e) =>
+                                                                                isEditing && updateOptionForBU(Number(selectedBU), idx, realIdx, { label: e.target.value })
+                                                                            }
+                                                                        />
+                                                                    </div>
+                                                                </div>
+                                                                <div className="flex justify-end border-t border-slate-100 pt-3">
+                                                                    <Button
+                                                                        type="button"
+                                                                        variant="ghost"
+                                                                        size="sm"
+                                                                        className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                                                                        disabled={!isEditing}
+                                                                        onClick={() => isEditing && removeOptionForBU(Number(selectedBU), idx, realIdx)}
+                                                                    >
+                                                                        <Trash2 className="h-4 w-4" aria-hidden />
+                                                                        Quitar opción
+                                                                    </Button>
+                                                                </div>
+                                                            </div>
+                                                        );
+                                                    })}
+
+                                                    {/* Opción "Otro" siempre al final */}
+                                                    {(c.options ?? []).filter(option => option.is_other).map((option) => {
+                                                        const realIdx = (c.options ?? []).findIndex(o => o === option);
+                                                        return (
+                                                            <div key={realIdx} className="space-y-3 rounded-lg border border-dashed border-slate-300 bg-slate-50/50 p-4">
+                                                                <p className="text-xs font-medium text-slate-500">Opción "Otro" — campo libre</p>
+                                                            </div>
+                                                        );
+                                                    })}
                                                 </div>
                                             )}
 

--- a/resources/js/pages/home.tsx
+++ b/resources/js/pages/home.tsx
@@ -51,7 +51,7 @@ export default function Home() {
                         <span className="text-gradient">Módulo de cotizaciones</span>
                     </h1>
                     <p className="mx-auto mt-6 max-w-xl text-base text-slate-600 md:text-lg">
-                        Configure su solicitud en pocos pasos: unidad de negocio, servicios y condiciones.
+                        Configure su solicitud en pocos pasos
                     </p>
 
                     <div className="animate-slide-up mt-10 flex flex-col items-center gap-4 sm:mt-12">
@@ -64,7 +64,7 @@ export default function Home() {
                         </Link>
                         <a
                             href="https://www.trainingcorporation.com.co/portafolio-de-servicios/"
-                            className="group inline-flex items-center justify-center gap-2 rounded-2xl border-2 border-slate-300 bg-white/80 px-8 py-4 text-base font-semibold text-slate-700 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-slate-400 hover:bg-white hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+                            className="group inline-flex items-center justify-center gap-2 rounded-2xl border-2 border-gray-500 bg-gray-500 px-8 py-4 text-base font-semibold text-white shadow-md shadow-gray-500/30 backdrop-blur-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-gray-600 hover:bg-gray-600 hover:shadow-lg hover:shadow-gray-500/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400"
                         >
                             Regresar al portafolio
                             <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" aria-hidden />

--- a/resources/views/emails/admin/quotation-pending.blade.php
+++ b/resources/views/emails/admin/quotation-pending.blade.php
@@ -21,6 +21,8 @@
       <td>
         <h3 style="margin:0 0 8px 0; font-size:15px; font-weight:bold; color:#1f2937;">Contacto</h3>
         <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Nombre:</strong> {{ $contact['name'] ?? '—' }}</p>
+        <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Empresa:</strong> {{ $contact['company'] ?? '—' }}</p>
+        <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Cargo:</strong> {{ $contact['role'] ?? '—' }}</p>
         <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Email:</strong> {{ $contact['email'] ?? '—' }}</p>
         <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Teléfono:</strong> {{ $contact['phone'] ?? '—' }}</p>
         <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Unidad de negocio:</strong> {{ $quotationOrder->business_unit ?? '—' }}</p>

--- a/resources/views/emails/quotation-pending.blade.php
+++ b/resources/views/emails/quotation-pending.blade.php
@@ -48,6 +48,9 @@
         @if(!empty($quotationOrder->gestion_line))
         <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Línea de gestión:</strong> {{ $quotationOrder->gestion_line }}</p>
         @endif
+        @if(!empty($quotationOrder->professional_id))
+        <p style="margin:4px 0; font-size:14px; color:#4b5563;"><strong>Profesional asignado:</strong> #{{ $quotationOrder->professional_id }}</p>
+        @endif
       </td>
     </tr>
   </table>


### PR DESCRIPTION
**Decision Tree (admin)**
- Added selection type per condition: single or multiple. Added "Allow other" checkbox at condition level (not per option)."Other" option always rendered last in the options list. Validation: cannot save without marking an initial condition. Improved cycle detection error message to show condition names instead of temporary IDs.

**Quotation flow (public view)**
- Checkboxes for multiple selection and radio buttons for single selection based on configuration. Free text field for "Other" option, both in single and multiple selection. Validation: Next/Finish button stays disabled if "Other" is selected without text. Pre-send summary displays answers in correct order (normal options first, "Other" last). Fixed [object Object] bug in summary when displaying multiple selection answers with "Other".